### PR TITLE
Add "NoSuchData" custom error

### DIFF
--- a/app/internal/domain/model/error.go
+++ b/app/internal/domain/model/error.go
@@ -5,3 +5,10 @@ type ErrorMessage struct {
 	// Message : Error message string.
 	Message string `json:"message"`
 }
+
+// NoSuchDataError : Wrap no such data error like `sql.ErrNoRows`
+type NoSuchDataError struct{}
+
+func (e NoSuchDataError) Error() string {
+	return "No such data"
+}

--- a/app/internal/handler/serp.go
+++ b/app/internal/handler/serp.go
@@ -69,8 +69,10 @@ func (s *Serp) FetchSerpWithDistributionByID(c echo.Context) error {
 
 	serp, err := s.usecase.FetchSerpWithRatio(task, offset, top)
 	if err != nil {
-		msg := model.ErrorMessage{
-			Message: "Database execution error: Failed to fetch relations: " + err.Error(),
+		if errors.Is(err, model.NoSuchDataError{}) {
+			return c.JSON(http.StatusNotFound, model.ErrorMessage{
+				Message: "Pages not found",
+			})
 		}
 		return c.JSON(http.StatusInternalServerError, msg)
 	}
@@ -130,10 +132,15 @@ func (s *Serp) FetchSerpWithIconByID(c echo.Context) error {
 
 	serp, err := s.usecase.FetchSerpWithIcon(task, offset, top)
 	if err != nil {
-		msg := model.ErrorMessage{
-			Message: "Database execution error: Failed to fetch relations : " + err.Error(),
+		if errors.Is(err, model.NoSuchDataError{}) {
+			return c.JSON(http.StatusNotFound, model.ErrorMessage{
+				Message: "Pages not found",
+			})
 		}
-		return c.JSON(http.StatusInternalServerError, msg)
+
+		return c.JSON(http.StatusInternalServerError, model.ErrorMessage{
+			Message: "Database execution error: Failed to fetch relations : " + err.Error(),
+		})
 	}
 
 	return c.JSON(http.StatusOK, serp)
@@ -173,6 +180,16 @@ func (s *Serp) FetchSerpByID(c echo.Context) error {
 	}
 
 	serp, err := s.usecase.FetchSerp(task, offset)
+	if err != nil {
+		if errors.Is(err, model.NoSuchDataError{}) {
+			return c.JSON(http.StatusNotFound, model.ErrorMessage{
+				Message: "Pages not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, model.ErrorMessage{
+			Message: "Database execution error: Failed to fetch relations: " + err.Error(),
+		})
+	}
 
 	return c.JSON(http.StatusOK, serp)
 }

--- a/app/internal/handler/serp_test.go
+++ b/app/internal/handler/serp_test.go
@@ -23,8 +23,11 @@ var (
 		err       error
 	}{
 
-		{"Want no error", map[string]interface{}{"task": 5, "offset": 0, "top": 3}, 200, false, nil},
-		{"Want no error", map[string]interface{}{"task": 6, "offset": 1, "top": 5}, 200, false, nil},
+		{"Want no error#1", map[string]interface{}{"task": 5, "offset": 0, "top": 3}, 200, false, nil},
+		{"Want no error#2", map[string]interface{}{"task": 6, "offset": 1, "top": 5}, 200, false, nil},
+		{"Want 404 code#1", map[string]interface{}{"task": 1, "offset": 1, "top": 5}, 404, false, nil},
+		{"Want 404 code#2", map[string]interface{}{"task": 10, "offset": 1, "top": 5}, 404, false, nil},
+		{"Want 404 code#3", map[string]interface{}{"task": 10, "offset": 10, "top": 5}, 404, false, nil},
 	}
 )
 
@@ -36,7 +39,15 @@ func TestFetchSerpWithDistributionByID(t *testing.T) {
 	mck := mock.NewMockSerp(ctrl)
 	for _, tt := range serpTests {
 		t.Run(tt.name, func(t *testing.T) {
-			mck.EXPECT().FetchSerpWithRatio(tt.in["task"], tt.in["offset"], tt.in["top"]).Return(nil, nil)
+			if tt.in["task"].(int) > 4 && tt.in["task"].(int) < 9 && tt.in["offset"].(int) < 10 {
+				mck.EXPECT().
+					FetchSerpWithRatio(tt.in["task"], tt.in["offset"], tt.in["top"]).
+					Return(nil, nil)
+			} else {
+				mck.EXPECT().
+					FetchSerpWithRatio(tt.in["task"], tt.in["offset"], tt.in["top"]).
+					Return(nil, model.NoSuchDataError{})
+			}
 			h := handler.NewSerpHandler(mck)
 
 			// Set query parameter
@@ -85,7 +96,15 @@ func TestFetchSerpWithIconByID(t *testing.T) {
 	mck := mock.NewMockSerp(ctrl)
 	for _, tt := range serpTests {
 		t.Run(tt.name, func(t *testing.T) {
-			mck.EXPECT().FetchSerpWithIcon(tt.in["task"], tt.in["offset"], tt.in["top"]).Return(nil, nil)
+			if tt.in["task"].(int) > 4 && tt.in["task"].(int) < 9 && tt.in["offset"].(int) < 10 {
+				mck.EXPECT().
+					FetchSerpWithIcon(tt.in["task"], tt.in["offset"], tt.in["top"]).
+					Return(nil, nil)
+			} else {
+				mck.EXPECT().
+					FetchSerpWithIcon(tt.in["task"], tt.in["offset"], tt.in["top"]).
+					Return(nil, model.NoSuchDataError{})
+			}
 			h := handler.NewSerpHandler(mck)
 
 			// Set query parameter
@@ -134,7 +153,13 @@ func TestFetchSerpByID(t *testing.T) {
 	mck := mock.NewMockSerp(ctrl)
 	for _, tt := range serpTests {
 		t.Run(tt.name, func(t *testing.T) {
-			mck.EXPECT().FetchSerp(tt.in["task"], tt.in["offset"]).Return(nil, nil)
+			if tt.in["task"].(int) > 4 && tt.in["task"].(int) < 9 && tt.in["offset"].(int) < 10 {
+				mck.EXPECT().FetchSerp(tt.in["task"], tt.in["offset"]).Return(nil, nil)
+			} else {
+				mck.EXPECT().
+					FetchSerp(tt.in["task"], tt.in["offset"]).
+					Return(nil, model.NoSuchDataError{})
+			}
 			h := handler.NewSerpHandler(mck)
 
 			// Set query parameter

--- a/app/internal/handler/task.go
+++ b/app/internal/handler/task.go
@@ -44,15 +44,11 @@ func (t *Task) FetchTaskInfo(c echo.Context) error {
 	// Fetch task information by task Id
 	ti, err := t.usecase.FetchTaskInfo(task)
 	if err != nil {
-		// [TODO] Wrap `sql.ErrNoRows` with original error and
-		// make it possible to distinguish with other error.
-		// (We would like to return 404 error)
-		// ---------------------------------------------------
-		// if err == sql.ErrNoRows {
-		// 	// Unreachable code block
-		// 	c.Echo().Logger.Infof("TaskId %v not found", taskId)
-		// 	return c.NoContent(http.StatusNotFound)
-		// }
+		if errors.Is(err, model.NoSuchDataError{}) {
+			return c.JSON(http.StatusNotFound, model.ErrorMessage{
+				Message: fmt.Sprintf("TaskId %v not found", taskId),
+			})
+		}
 		c.Echo().Logger.Errorf("Database Execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}

--- a/app/internal/handler/task_test.go
+++ b/app/internal/handler/task_test.go
@@ -19,14 +19,19 @@ import (
 var (
 	taskTests = []struct {
 		name      string
-		in        interface{}
+		in        int
 		want      interface{}
 		wantError bool
 		err       error
 	}{
-		{"Want no error", 5, 200, false, nil},
-		// [TODO]
-		// {"Want no error", 4, 404, false, nil},
+		{"Want 404 error#1", 1, 404, false, nil},
+		{"Want 404 error#2", 2, 404, false, nil},
+		{"Want 404 error#3", 3, 404, false, nil},
+		{"Want 404 error#4", 4, 404, false, nil},
+		{"Want no error#1", 5, 200, false, nil},
+		{"Want no error#2", 6, 200, false, nil},
+		{"Want no error#3", 7, 200, false, nil},
+		{"Want no error#4", 8, 200, false, nil},
 	}
 
 	answerTests = []struct {
@@ -54,7 +59,11 @@ func TestFetchTaskInfo(t *testing.T) {
 	mck := mock.NewMockTask(ctrl)
 	for _, tt := range taskTests {
 		t.Run(tt.name, func(t *testing.T) {
-			mck.EXPECT().FetchTaskInfo(tt.in).Return(nil, nil)
+			if tt.in > 4 && tt.in < 9 {
+				mck.EXPECT().FetchTaskInfo(tt.in).Return(model.Task{}, nil)
+			} else {
+				mck.EXPECT().FetchTaskInfo(tt.in).Return(model.Task{}, model.NoSuchDataError{})
+			}
 			h := handler.NewTaskHandler(mck)
 
 			req := httptest.NewRequest(

--- a/app/internal/infra/mysql/serp.go
+++ b/app/internal/infra/mysql/serp.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"database/sql"
 	"ratri/internal/domain/model"
 	repo "ratri/internal/domain/repository"
 
@@ -31,9 +32,19 @@ func (s SerpReporitoryImpl) FetchSerpByTaskID(taskId, offset int) ([]model.Searc
 			?, 10
 	`, taskId, offset*10)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return &srp, model.NoSuchDataError{}
+		}
 		return nil, err
 	}
-	return srp, nil
+
+	// `sqlx.DB.Select` does not throw `ErrNoRows`,
+	// so if length of fetched array is 0, return `model.NoSuchDataError`
+	if len(srp) == 0 {
+		return &srp, model.NoSuchDataError{}
+	}
+
+	return &srp, nil
 }
 
 func (s SerpReporitoryImpl) FetchSerpWithIconByTaskID(taskId, offset, top int) ([]model.SerpWithIconQueryResult, error) {
@@ -135,7 +146,13 @@ func (s SerpReporitoryImpl) FetchSerpWithIconByTaskID(taskId, offset, top int) (
 		return nil, err
 	}
 
-	return swi, nil
+	// `sqlx.DB.Select` does not throw `ErrNoRows`,
+	// so if length of fetched array is 0, return `model.NoSuchDataError`
+	if len(swi) == 0 {
+		return &swi, model.NoSuchDataError{}
+	}
+
+	return &swi, nil
 }
 
 func (s SerpReporitoryImpl) FetchSerpWithRatioByTaskID(taskId, offset, top int) ([]model.SerpWithRatioQueryResult, error) {
@@ -202,8 +219,17 @@ func (s SerpReporitoryImpl) FetchSerpWithRatioByTaskID(taskId, offset, top int) 
 			) as relation_count
 	`, taskId, offset*10)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return &swr, model.NoSuchDataError{}
+		}
 		return nil, err
 	}
 
-	return swr, nil
+	// `sqlx.DB.Select` does not throw `ErrNoRows`,
+	// so if length of fetched array is 0, return `model.NoSuchDataError`
+	if len(swr) == 0 {
+		return &swr, model.NoSuchDataError{}
+	}
+
+	return &swr, nil
 }

--- a/app/internal/infra/mysql/task.go
+++ b/app/internal/infra/mysql/task.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"database/sql"
 	"ratri/internal/domain/model"
 	repo "ratri/internal/domain/repository"
 
@@ -32,7 +33,10 @@ func (t TaskRepositoryImpl) FetchTaskInfo(taskId int) (*model.Task, error) {
 		`, taskId)
 
 	if err := row.StructScan(&task); err != nil {
-		return nil, err
+		if err == sql.ErrNoRows {
+			return task, model.NoSuchDataError{}
+		}
+		return task, err
 	}
 
 	return &task, nil
@@ -93,6 +97,9 @@ func (t TaskRepositoryImpl) GetTaskIdsByGroupId(groupId int) ([]int, error) {
 	`, groupId)
 
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, model.NoSuchDataError{}
+		}
 		return nil, err
 	}
 
@@ -112,6 +119,9 @@ func (t TaskRepositoryImpl) GetConditionIdByGroupId(groupId int) (int, error) {
 	`, groupId)
 
 	if err := row.Scan(&condition); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, model.NoSuchDataError{}
+		}
 		return 0, err
 	}
 

--- a/app/internal/infra/mysql/task_test.go
+++ b/app/internal/infra/mysql/task_test.go
@@ -2,7 +2,6 @@ package mysql_test
 
 import (
 	"ratri/internal/domain/model"
-	"reflect"
 	"testing"
 )
 
@@ -14,14 +13,15 @@ var (
 		wantError bool
 		err       error
 	}{
-		{"Want no error", 1, nil, false, nil},
-		{"Want no error", 2, nil, false, nil},
-		{"Want no error", 3, nil, false, nil},
-		{"Want no error", 4, nil, false, nil},
-		{"Want no error", 5, &model.Task{}, false, nil},
-		{"Want no error", 6, &model.Task{}, false, nil},
-		{"Want no error", 7, &model.Task{}, false, nil},
-		{"Want no error", 8, &model.Task{}, false, nil},
+
+		{"Want no data error#1", 1, nil, true, model.NoSuchDataError{}},
+		{"Want no data error#2", 2, nil, true, model.NoSuchDataError{}},
+		{"Want no data error#3", 3, nil, true, model.NoSuchDataError{}},
+		{"Want no data error#4", 4, nil, true, model.NoSuchDataError{}},
+		{"Want no error#5", 5, &model.Task{}, false, nil},
+		{"Want no error#6", 6, &model.Task{}, false, nil},
+		{"Want no error#7", 7, &model.Task{}, false, nil},
+		{"Want no error#8", 8, &model.Task{}, false, nil},
 	}
 )
 
@@ -39,8 +39,12 @@ func TestFetchTaskInfo(t *testing.T) {
 				}
 			}
 
-			if reflect.DeepEqual(tt.want, task) {
-				t.Fatal(err)
+			// if reflect.DeepEqual(tt.want, *task) {
+			// 	t.Fatalf("Want %#v, but got %#v:\n %#v", tt.want, task, err)
+			// }
+
+			if tt.want == task {
+				t.Fatalf("Want %#v, but got %#v:\n %#v", tt.want, task, err)
 			}
 
 		})

--- a/app/internal/infra/mysql/user.go
+++ b/app/internal/infra/mysql/user.go
@@ -59,7 +59,10 @@ func (u UserRepositoryImpl) FindById(userId int) (*model.User, error) {
 			id = ?
 	`, userId)
 	if err := row.StructScan(&user); err != nil {
-		return nil, err
+		if err == sql.ErrNoRows {
+			return user, model.NoSuchDataError{}
+		}
+		return user, err
 	}
 	return &user, nil
 }
@@ -77,7 +80,10 @@ func (u UserRepositoryImpl) FindByUid(uid string) (*model.User, error) {
 			uid = ?
 	`, uid)
 	if err != nil {
-		return nil, err
+		if err == sql.ErrNoRows {
+			return user, model.NoSuchDataError{}
+		}
+		return user, err
 	}
 	return &user, nil
 }
@@ -111,12 +117,15 @@ func (u UserRepositoryImpl) GetCompletionCodeById(userId int) (int, error) {
 	`, userId)
 
 	if err := row.Scan(&code); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, model.NoSuchDataError{}
+		}
 		return 0, err
 	}
 
 	if code.Valid {
 		return int(code.Int64), nil
 	} else {
-		return 42, sql.ErrNoRows
+		return 42, model.NoSuchDataError{}
 	}
 }


### PR DESCRIPTION
## Description

To return 404 error in handler, I added a custom error (wrapper of `sql.ErrNoRows` ) and distinguish with other errors.

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
